### PR TITLE
Change title text, fix spelling

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -8,10 +8,10 @@ function Page({children}) {
   return (<>
     <Segment as="header" basic vertical inverted>
       <Menu as="nav" size="massive" color="teal" secondary pointing className="container">
-        <Menu.Item as={NavLink} to="/" end className="mac-logo">Mapping Action Collective</Menu.Item>
+        <Menu.Item as={NavLink} to="/" end className="mac-logo">Healthy Transitions</Menu.Item>
         <Menu.Item as={NavLink} to="/" end>Oregon Youth Resource Map</Menu.Item>
         <Menu.Item as={NavLink} to="/about" position="right"><header>About</header></Menu.Item>
-        <Menu.Item as={NavLink} to="/suggest"><header>Suggest Upate</header></Menu.Item>
+        <Menu.Item as={NavLink} to="/suggest"><header>Suggest Update</header></Menu.Item>
       </Menu>
     </Segment>
     {children}


### PR DESCRIPTION
With an eye to our current round of funding applications, we need the upper left text to say, "Healthy Transitions" instead of "Mapping Action Collective." This may be a temporary or permanent change, but needs to stay in place until at least Jan 7, 2022.