### PR TITLE
Make phone labels optional, add phone_1_after field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
-# Getting Started with Create React App
+# Oregon Youth Resource Map FE
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+**Developers: Please read the [Contributing to the Repository Guide](https://github.com/mapping-action-collective/healthy-transitions-frontend/wiki/Contributing-to-the-Repository) to get started.** 
 
+[Looking for the Oregon Youth Resource Map Backend?](https://github.com/mapping-action-collective/healthy-transitions-backend)
+
+## About
+
+The [Oregon Youth Resource Map](https://oregonyouthresourcemap.com/) is a website & mobile app that displays mental health resources for Oregon youth, ages 16-25. 
+
+The code is developed and maintained by the [Mapping Action Collective (MAC)](https://mappingaction.org/who-we-are/), in partnership with SAMHSA, Direction Service, Healthy Transitions Transitions, PSU, and more. 
+
+## To Contribute
+- Read the [Contributing to the Repository Guide](https://github.com/mapping-action-collective/healthy-transitions-frontend/wiki/Contributing-to-the-Repository)
+- Check in with the MAC project lead for more instructions 
+
+## About Create React App
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -85,29 +85,17 @@ const CardCornerDropdown = ({ index, guid, full_address='', mapRef }) => {
   return (
     <Dropdown icon='angle down' direction='left'>
       <Dropdown.Menu>
-
-        {/* Proposed optonal UI element for saving listings */}
-        {/* <Dropdown.Item id={guid} text='Save listing' icon={{ name: 'heart outline', color: getColor(index)}} onClick={() => console.log(guid)} /> */}
-
-        {/* This copies the URL of the card to the user's clipboard. 
-        - TODO: add a UI element that conveys "Link copied!" on success 
-        - TODO: investigate accessibility of Semantic UI dropdowns.
-        */}
         <Dropdown.Item text='Copy link'icon='share alternate'
         onClick={() => navigator.clipboard.writeText(`oregonyouthresourcemap.com/#/${guid}`)}
         />
-
-        {/* Links to map when applicable. Does not display on cards with no address.  */}
         {full_address && <Dropdown.Item style={{ cursor: 'pointer' }} onClick={() => navigate(`/${guid}`, { state: { scrollToMap: true } }) } text='View on map' icon={{ name: 'map outline', color: getColor(index)}}/>}
-
-        {/* External link to Google feedback form, as requested by HT youth  */}
-        <Dropdown.Item as="a" href='https://forms.gle/Ldo4ortzkNHDxSGB8' target='_blank' text='Comment'icon={{ name: 'chat', color: getColor(index)}} />
+        <Dropdown.Item as="a" href='https://oregonyouthresourcemap.com/#/suggest' target='_blank' text='Comment'icon={{ name: 'chat', color: getColor(index)}} />
       </Dropdown.Menu>
     </Dropdown>
   )
 }
 
-const MapCard = forwardRef(({ mapRef, listing: { guid, category, coords, parent_organization, full_name, full_address, description, phone_1, phone_label_1, phone_2, phone_label_2, crisis_line_number, crisis_line_label, website, blog_link, twitter_link, facebook_link, youtube_link, instagram_link, program_email, video_description, languages_offered, services_provided, keywords, min_age, max_age, eligibility_requirements, ...listing}, index}, ref) => {
+const MapCard = forwardRef(({ mapRef, listing: { guid, category, coords, parent_organization, full_name, full_address, description, text_message_instructions, phone_1, phone_label_1, phone_1_ext, phone_2, phone_label_2, crisis_line_number, crisis_line_label, website, blog_link, twitter_link, facebook_link, youtube_link, instagram_link, program_email, video_description, languages_offered, services_provided, keywords, min_age, max_age, eligibility_requirements, ...listing}, index}, ref) => {
   const navigate = useNavigate()
   const [ searchParams, setSearchParams ] = useSearchParams()
   return (
@@ -122,9 +110,11 @@ const MapCard = forwardRef(({ mapRef, listing: { guid, category, coords, parent_
           { full_address && <Card.Meta style={{ cursor: 'pointer' }} onClick={() => { navigate(`/${guid}`, { state: { scrollToMap: true } }) }} title="View on map"><Icon name="map marker alternate" /> {full_address}</Card.Meta> }
           <Segment secondary>
             { full_address && <Card.Description><Icon name="map marker alternate" /><a target="_blank" rel="noreferrer" href={`https://www.google.com/maps/dir//${encodeURIComponent(full_address)}`}>Get Directions <sup><Icon size="small" name="external" /></sup></a></Card.Description> }
-            { phone_1 && <Card.Description><Icon name="phone" />{phone_label_1}: <a target="_blank" rel="noreferrer" href={`tel:${phone_1}`}>{phone_1}</a></Card.Description> }
-            { phone_2 && <Card.Description><Icon name="phone" />{phone_label_2}: <a target="_blank" rel="noreferrer" href={`tel:${phone_2}`}>{phone_2}</a></Card.Description> }
+            { phone_1 && <Card.Description><Icon name="phone" />{ phone_label_1 && `${phone_label_1}:` } <a target="_blank" rel="noreferrer" href={`tel:${phone_1}`}>{phone_1}</a> { phone_1_ext && phone_1_ext}</Card.Description> }
+            { phone_2 && <Card.Description><Icon name="phone" />{ phone_label_2 && `${phone_label_2}:` } <a target="_blank" rel="noreferrer" href={`tel:${phone_2}`}>{phone_2}</a></Card.Description> }
             { crisis_line_number && <Card.Description><Icon name="phone" />{crisis_line_label}: <a target="_blank" rel="noreferrer" href={`tel:${crisis_line_number}`}>{crisis_line_number}</a></Card.Description> }
+            {/* Note: text message instructions are almost always strings that include non-numeric information. They should not be hyperlinked */}
+            { text_message_instructions && <Card.Description><Icon name="comment alternate" /> {text_message_instructions}</Card.Description> }
             { website && <Card.Description><Icon name="globe" /><a target="_blank" rel="noreferrer" href={website}>Website</a></Card.Description> }
             { blog_link && <Card.Description><Icon name="globe" /><a target="_blank" rel="noreferrer" href={blog_link}>{blog_link}</a></Card.Description> }
             { twitter_link && <Card.Description><Icon name="twitter" /><a target="_blank" rel="noreferrer" href={twitter_link}>{twitter_link}</a></Card.Description> }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -110,8 +110,8 @@ const MapCard = forwardRef(({ mapRef, listing: { guid, category, coords, parent_
           { full_address && <Card.Meta style={{ cursor: 'pointer' }} onClick={() => { navigate(`/${guid}`, { state: { scrollToMap: true } }) }} title="View on map"><Icon name="map marker alternate" /> {full_address}</Card.Meta> }
           <Segment secondary>
             { full_address && <Card.Description><Icon name="map marker alternate" /><a target="_blank" rel="noreferrer" href={`https://www.google.com/maps/dir//${encodeURIComponent(full_address)}`}>Get Directions <sup><Icon size="small" name="external" /></sup></a></Card.Description> }
-            { phone_1 && <Card.Description><Icon name="phone" />{ phone_label_1 && `${phone_label_1}:` } <a target="_blank" rel="noreferrer" href={`tel:${phone_1}`}>{phone_1}</a> { phone_1_ext && phone_1_ext}</Card.Description> }
-            { phone_2 && <Card.Description><Icon name="phone" />{ phone_label_2 && `${phone_label_2}:` } <a target="_blank" rel="noreferrer" href={`tel:${phone_2}`}>{phone_2}</a></Card.Description> }
+            { phone_1 && <Card.Description><Icon name="phone" />{ phone_label_1 && `${phone_label_1}:` }<a target="_blank" rel="noreferrer" href={`tel:${phone_1}`}>{phone_1}</a> { phone_1_ext && phone_1_ext}</Card.Description> }
+            { phone_2 && <Card.Description><Icon name="phone" />{ phone_label_2 && `${phone_label_2}:` }<a target="_blank" rel="noreferrer" href={`tel:${phone_2}`}>{phone_2}</a></Card.Description> }
             { crisis_line_number && <Card.Description><Icon name="phone" />{crisis_line_label}: <a target="_blank" rel="noreferrer" href={`tel:${crisis_line_number}`}>{crisis_line_number}</a></Card.Description> }
             {/* Note: text message instructions are almost always strings that include non-numeric information. They should not be hyperlinked */}
             { text_message_instructions && <Card.Description><Icon name="comment alternate" /> {text_message_instructions}</Card.Description> }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -110,8 +110,8 @@ const MapCard = forwardRef(({ mapRef, listing: { guid, category, coords, parent_
           { full_address && <Card.Meta style={{ cursor: 'pointer' }} onClick={() => { navigate(`/${guid}`, { state: { scrollToMap: true } }) }} title="View on map"><Icon name="map marker alternate" /> {full_address}</Card.Meta> }
           <Segment secondary>
             { full_address && <Card.Description><Icon name="map marker alternate" /><a target="_blank" rel="noreferrer" href={`https://www.google.com/maps/dir//${encodeURIComponent(full_address)}`}>Get Directions <sup><Icon size="small" name="external" /></sup></a></Card.Description> }
-            { phone_1 && <Card.Description><Icon name="phone" />{ phone_label_1 && `${phone_label_1}:` }<a target="_blank" rel="noreferrer" href={`tel:${phone_1}`}>{phone_1}</a> { phone_1_ext && phone_1_ext}</Card.Description> }
-            { phone_2 && <Card.Description><Icon name="phone" />{ phone_label_2 && `${phone_label_2}:` }<a target="_blank" rel="noreferrer" href={`tel:${phone_2}`}>{phone_2}</a></Card.Description> }
+            { phone_1 && <Card.Description><Icon name="phone" />{ phone_label_1 && `${phone_label_1}: ` }<a target="_blank" rel="noreferrer" href={`tel:${phone_1}`}>{phone_1}</a> { phone_1_ext && phone_1_ext}</Card.Description> }
+            { phone_2 && <Card.Description><Icon name="phone" />{ phone_label_2 && `${phone_label_2}: ` }<a target="_blank" rel="noreferrer" href={`tel:${phone_2}`}>{phone_2}</a></Card.Description> }
             { crisis_line_number && <Card.Description><Icon name="phone" />{crisis_line_label}: <a target="_blank" rel="noreferrer" href={`tel:${crisis_line_number}`}>{crisis_line_number}</a></Card.Description> }
             {/* Note: text message instructions are almost always strings that include non-numeric information. They should not be hyperlinked */}
             { text_message_instructions && <Card.Description><Icon name="comment alternate" /> {text_message_instructions}</Card.Description> }


### PR DESCRIPTION
**Note: This works with prod data, but to properly view the changes, use the staging data.**

**To view online: https://hto2020-fron-optional-p-c1iyhh.herokuapp.com/?api=https://hto2020-backend-staging.herokuapp.com/api-preview/#/**

To view locally (once running): [http://localhost:3000/?api=http://hto2020-backend-staging.herokuapp.com/api-preview](http://localhost:3000/?api=http://hto2020-backend-staging.herokuapp.com/api-preview)

This PR: 
- [x] Adds a display field to display text_message_instructions (string, non-hyperlinked)
<img width="501" alt="Screen Shot 2022-01-16 at 11 02 23 AM" src="https://user-images.githubusercontent.com/49598669/149674311-05053f48-aa79-4dc2-81f5-3ef563e1e3ee.png">

- [x] Makes phone labels optional, and doesn't display them if they're not present in the data
<img width="599" alt="Screen Shot 2022-01-16 at 10 12 42 AM" src="https://user-images.githubusercontent.com/49598669/149674321-3726bb25-0648-4926-b6d1-ca499a62102e.png">

- [x] Adds a phone_1_ext field (string, displays after phone_1)
<img width="525" alt="Screen Shot 2022-01-16 at 10 59 53 AM" src="https://user-images.githubusercontent.com/49598669/149674290-425e5996-0b22-45aa-9ac2-91e0768539f1.png">

No regressions or breaking changes. It adds 2 fields to the Card display, and does not remove any.